### PR TITLE
Release 3.0

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -11,5 +11,5 @@
   ],
   "rules": {
   },
-  "ignorePatterns": ["test/**/*", "dist/**/*", "node_modules/**/*"]
+  "ignorePatterns": ["test/**/*", "dist/**/*", "node_modules/**/*", "scripts/**/*"]
 }

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ bun add assemblyai
 Import the AssemblyAI package and create an AssemblyAI object with your API key:
 
 ```javascript
-import AssemblyAI from "assemblyai";
+import { AssemblyAI } from "assemblyai";
 
 const client = new AssemblyAI({
   apiKey: process.env.ASSEMBLYAI_API_KEY,
@@ -94,7 +94,7 @@ const transcript = await client.transcripts.get(transcript.id)
 
 ## List transcripts
 
-This will return a paged list of transcripts that you have transcript.
+This will return a page of transcripts that you have transcript.
 
 ```javascript
 const page = await client.transcripts.list()

--- a/jest.config.rollup.ts
+++ b/jest.config.rollup.ts
@@ -7,6 +7,7 @@ const jestConfig: JestConfigWithTsJest = {
   moduleNameMapper: {
     "^@/(.*)$": "<rootDir>/src/$1",
   },
+  modulePathIgnorePatterns: ['<rootDir>/dist'],
 };
 
 process.env.TESTDATA_DIR = "tests/static";

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "assemblyai",
-  "version": "2.0.2",
+  "version": "3.0.0",
   "description": "The AssemblyAI Node.js SDK provides an easy-to-use interface for interacting with the AssemblyAI API, which supports async and real-time transcription, as well as the latest LeMUR models.",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,20 +1,20 @@
 const pkg = require('./package.json')
 const ts = require('rollup-plugin-typescript2')
 
-const plugins = [
-  ts({
-    tsconfigOverride: { exclude: ['**/*.test.ts'] },
-  }),
-]
-
 module.exports = [
   {
-    input: 'src/index.ts',
-    output: [
-      { file: pkg.main, format: 'cjs' },
-      { file: pkg.module, format: 'es' }
+    plugins: [
+      ts({
+        tsconfigOverride: { exclude: ['**/*.test.ts'] },
+      })
     ],
-    plugins,
-    external: ['axios', 'fs/promises', 'stream', 'ws']
-  },
+    external: ['axios', 'fs', 'stream', 'ws'],
+    input: 'src/index.ts',
+    output:
+      [{
+        file: pkg.main, format: 'cjs', exports: 'named'
+      }, {
+        file: pkg.module, format: 'es', exports: 'named'
+      }]
+  }
 ]

--- a/scripts/kitchensink.ts
+++ b/scripts/kitchensink.ts
@@ -1,7 +1,16 @@
 import { createReadStream } from 'fs'
 import 'dotenv/config'
-import AssemblyAI, { Transcript, CreateTranscriptParameters } from '../src/index';
-import { FinalTranscript, LemurBaseResponse, PartialTranscript, RealtimeTranscript } from '../src/types'
+import
+{
+  AssemblyAI,
+  Transcript,
+  CreateTranscriptParameters,
+  FinalTranscript,
+  LemurBaseResponse,
+  PartialTranscript,
+  RealtimeTranscript
+} from '../src';
+
 
 const client = new AssemblyAI({
   apiKey: process.env.ASSEMBLYAI_API_KEY || '',
@@ -63,6 +72,11 @@ const createTranscriptParams: CreateTranscriptParameters = {
   punctuate: false,
   speech_threshold: 0.5,
 };
+
+(async function uploadFileFromPath() {
+  const uploadUrl = await client.files.upload('./tests/static/gore.wav');
+  console.log('Upload URL:', uploadUrl);
+})();
 
 (async function createStandardTranscript() {
   const transcript = await client.transcripts.create(createTranscriptParams);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,2 @@
-import * as services from "./services";
-import { AssemblyAI } from "./services";
-export * from "./services";
 export type * from "./types";
-export default AssemblyAI;
-class AssemblyAIExports extends AssemblyAI {}
-module.exports = Object.assign(AssemblyAIExports, services);
+export * from "./services";

--- a/src/services/files/index.ts
+++ b/src/services/files/index.ts
@@ -1,21 +1,29 @@
-import { readFile } from "fs/promises";
+// import the fs module instead if specific named exports
+// to keep the assemblyai module more compatible. Some fs polyfills don't include `createReadStream`.
+import fs from "fs";
 import { BaseService } from "@/services/base";
-import { UploadedFile } from "@/types";
+import { UploadedFile, FileUploadParameters, FileUploadData } from "@/types";
 
 export class FileService extends BaseService {
   /**
    * Upload a local file to AssemblyAI.
-   * @param path The local file to upload.
+   * @param input The local file path to upload, or a stream or buffer of the file to upload.
    * @return A promise that resolves to the uploaded file URL.
    */
-  async upload(path: string): Promise<string> {
-    const file = await readFile(path);
+  async upload(input: FileUploadParameters): Promise<string> {
+    let fileData: FileUploadData;
+    if (typeof input === "string") fileData = fs.createReadStream(input);
+    else fileData = input;
 
-    const { data } = await this.client.post<UploadedFile>("/v2/upload", file, {
-      headers: {
-        "Content-Type": "application/octet-stream",
-      },
-    });
+    const { data } = await this.client.post<UploadedFile>(
+      "/v2/upload",
+      fileData,
+      {
+        headers: {
+          "Content-Type": "application/octet-stream",
+        },
+      }
+    );
 
     return data.upload_url;
   }

--- a/src/services/transcripts/index.ts
+++ b/src/services/transcripts/index.ts
@@ -12,6 +12,7 @@ import {
   Retrieveable,
   SubtitleFormat,
   RedactedAudioResponse,
+  TranscriptListParameters,
   WordSearchResponse,
 } from "@/types";
 import { AxiosInstance } from "axios";
@@ -87,16 +88,23 @@ export class TranscriptService
     return res.data;
   }
 
-  // TODO: add options overload to support list querystring parameters
   /**
-   * Retrieves a paged list of transcript listings.
-   * @param nextUrl The URL to retrieve the transcript list from. If not provided, the first page will be retrieved.
-   * @returns
+   * Retrieves a page of transcript listings.
+   * @param parameters The parameters to filter the transcript list by, or the URL to retrieve the transcript list from.
    */
-  async list(nextUrl?: string | null): Promise<TranscriptList> {
-    const { data } = await this.client.get<TranscriptList>(
-      nextUrl ?? "/v2/transcript"
-    );
+  async list(
+    parameters?: TranscriptListParameters | string
+  ): Promise<TranscriptList> {
+    let url = "/v2/transcript";
+    let query: TranscriptListParameters | undefined;
+    if (typeof parameters === "string") {
+      url = parameters;
+    } else if (parameters) {
+      query = parameters;
+    }
+    const { data } = await this.client.get<TranscriptList>(url, {
+      params: query,
+    });
     for (const transcriptListItem of data.transcripts) {
       transcriptListItem.created = new Date(transcriptListItem.created);
       if (transcriptListItem.completed) {

--- a/src/types/files/index.ts
+++ b/src/types/files/index.ts
@@ -1,0 +1,10 @@
+type FileUploadParameters = string | FileUploadData;
+type FileUploadData =
+  | NodeJS.ReadableStream
+  | ReadableStream
+  | Buffer
+  | ArrayBufferView
+  | ArrayBufferLike
+  | Uint8Array;
+
+export type { FileUploadParameters, FileUploadData };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,4 @@
+export type * from "./files";
 export type * from "./transcripts";
 export type * from "./realtime";
 export type * from "./services";

--- a/src/types/openapi.generated.ts
+++ b/src/types/openapi.generated.ts
@@ -762,6 +762,28 @@ export type TranscriptListItem = {
   status: TranscriptStatus;
 };
 
+export type TranscriptListParameters = {
+  /** @description Get transcripts that were created after this transcript ID */
+  after_id?: string;
+  /** @description Get transcripts that were created before this transcript ID */
+  before_id?: string;
+  /**
+   * Format: date
+   * @description Only get transcripts created on this date
+   */
+  created_on?: string;
+  /**
+   * Format: int64
+   * @description Maximum amount of transcripts to retrieve
+   * @default 10
+   */
+  limit?: number;
+  /** @description Filter by transcript status */
+  status?: TranscriptStatus;
+  /** @description Only get throttled transcripts, overrides the status filter */
+  throttled_only?: boolean;
+};
+
 export type TranscriptParagraph = {
   /** Format: double */
   confidence: number;

--- a/src/utils/axios.ts
+++ b/src/utils/axios.ts
@@ -1,5 +1,5 @@
 import axios, { isAxiosError } from "axios";
-import { BaseServiceParams } from "../.";
+import { BaseServiceParams } from "@/types";
 
 export function createAxiosClient(params: BaseServiceParams) {
   const client = axios.create({

--- a/tests/file.test.ts
+++ b/tests/file.test.ts
@@ -1,4 +1,6 @@
-import AssemblyAI from '../src'
+import { AssemblyAI } from '../src'
+import { createReadStream } from "fs";
+import { readFile } from "fs/promises";
 import path from "path"
 
 const testDir = process.env["TESTDATA_DIR"] ?? '.'
@@ -8,16 +10,23 @@ const assembly = new AssemblyAI({
 })
 
 describe('files', () => {
-  it('should upload a file', async () => {
+  it('should upload a file from path', async () => {
     const uploadUrl = await assembly.files.upload(path.join(testDir, 'gore.wav'))
 
     expect(uploadUrl).toBeTruthy()
-  }, 10_000)
+  })
 
-  it('should not find file', async () => {
-    const promise = assembly.files.upload(path.join(testDir, 'bad-path.wav'))
-    await expect(promise).rejects.toThrowError(
-      "ENOENT: no such file or directory, open '" + testDir + "/bad-path.wav'",
-    )
+  it('should upload a file from stream', async () => {
+    const stream = createReadStream(path.join(testDir, 'gore.wav'))
+    const uploadUrl = await assembly.files.upload(stream)
+
+    expect(uploadUrl).toBeTruthy()
+  })
+
+  it('should upload a file from buffer', async () => {
+    const data = await readFile(path.join(testDir, 'gore.wav'))
+    const uploadUrl = await assembly.files.upload(data)
+
+    expect(uploadUrl).toBeTruthy()
   })
 })

--- a/tests/lemur.test.ts
+++ b/tests/lemur.test.ts
@@ -1,5 +1,5 @@
 import { knownTranscriptIds, knownLemurRequestId, purgeRequestId } from './__mocks__/api'
-import AssemblyAI from '../src'
+import { AssemblyAI } from '../src'
 
 const assembly = new AssemblyAI({
   apiKey: '',

--- a/tests/realtime.test.ts
+++ b/tests/realtime.test.ts
@@ -1,5 +1,5 @@
 import WS from "jest-websocket-mock";
-import AssemblyAI, { RealtimeService } from '../src'
+import { AssemblyAI, RealtimeService } from '../src'
 import {
   RealtimeError,
   RealtimeErrorType,

--- a/tests/transcript.test.ts
+++ b/tests/transcript.test.ts
@@ -1,6 +1,6 @@
 import { knownTranscriptIds } from './__mocks__/api'
 import axios, { withData } from './__mocks__/axios'
-import AssemblyAI from '../src'
+import { AssemblyAI } from '../src'
 import path from "path"
 
 const testDir = process.env["TESTDATA_DIR"] ?? '.'
@@ -14,6 +14,10 @@ const remoteAudioURL =
   'https://storage.googleapis.com/aai-web-samples/espn-bears.m4a'
 const badRemoteAudioURL =
   'https://storage.googleapis.com/aai-web-samples/does-not-exist.m4a'
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
 
 describe('core', () => {
   it('should create the transcript object with a remote url', async () => {
@@ -67,7 +71,7 @@ describe('core', () => {
     expect(transcript.status).toBe('completed')
   }, 6000)
 
-  it('should list the transcript objects', async () => {
+  it('should retrieve a page of transcripts', async () => {
     const page = await assembly.transcripts.list()
     expect(page.transcripts).toBeInstanceOf(Array)
     expect(page.page_details).not.toBeNull()

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "outDir": "./dist",
     "rootDir": "./src",
-
     "module": "esnext",
     "moduleResolution": "node",
     "target": "es6",
@@ -11,7 +10,6 @@
     "removeComments": false,
     "strict": true,
     "forceConsistentCasingInFileNames": true,
-
     "esModuleInterop": true,
     "paths": {
       "@/*": ["./src/*"]


### PR DESCRIPTION
### Changed
- `AssemblyAI.files.upload` accepts streams and buffers, in addition to a string (path to file).

### Removed
- **Breaking**: The module does not have a default export anymore, because of inconsistent functionality across module systems. Instead, use `AssemblyAI` as a named import like this: `import { AssemblyAI } from 'assemblyai'`.