### PR TITLE
Release 3.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![AssemblyAI Twitter](https://img.shields.io/twitter/follow/AssemblyAI?label=%40AssemblyAI&style=social)](https://twitter.com/AssemblyAI)
 [![AssemblyAI YouTube](https://img.shields.io/youtube/channel/subscribers/UCtatfZMf-8EkIwASXM4ts0A)](https://www.youtube.com/@AssemblyAI)
 [![Discord](https://img.shields.io/discord/875120158014853141?logo=discord&label=Discord&link=https%3A%2F%2Fdiscord.com%2Fchannels%2F875120158014853141&style=social)
-](https://discord.gg/5aQNZyq3)
+](https://assemblyai.com/discord)
 
 # AssemblyAI Node.js SDK
 
@@ -79,7 +79,7 @@ const transcript = await client.transcripts.create({
   poll: true,
   // How frequently the transcript is polled in ms. Defaults to 3000.
   pollingInterval: 1000,
-  // How long to wait in ms until the "Polling timeout" error is thrown. Defaults to 180000.
+  // How long to wait in ms until the "Polling timeout" error is thrown. Defaults to infinite (-1).
   pollingTimeout: 5000,
 })
 ```
@@ -92,9 +92,21 @@ This will return the transcript object in its current state. If the transcript i
 const transcript = await client.transcripts.get(transcript.id)
 ```
 
+If you disabled polling during transcript creation, you can still poll until the transcript `status` is `completed` or `error` using `waitUntilReady`:
+
+```javascript
+const transcript = await client.transcripts.waitUntilReady(transcript.id,
+{
+  // How frequently the transcript is polled in ms. Defaults to 3000.
+  pollingInterval: 1000,
+  // How long to wait in ms until the "Polling timeout" error is thrown. Defaults to infinite (-1).
+  pollingTimeout: 5000,
+})
+```
+
 ## List transcripts
 
-This will return a page of transcripts that you have created.
+This will return a page of transcripts you created.
 
 ```javascript
 const page = await client.transcripts.list()

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
-export type * from "./types";
+export * from "./types";
 export * from "./services";

--- a/src/types/asyncapi.generated.ts
+++ b/src/types/asyncapi.generated.ts
@@ -14,19 +14,19 @@ type OneOf<T extends any[]> = T extends [infer Only]
   : never;
 
 export type AudioData = {
-  /** @description Raw audio data, base64 encoded. This can be the raw data recorded directly from a microphone or read from an audio file. */
+  /** @description Base64 encoded raw audio data */
   audio_data: string;
 };
 
 export type FinalTranscript = RealtimeBaseTranscript & {
   /**
-   * @description Describes the type of message.
+   * @description Describes the type of message
    * @constant
    */
   message_type: "FinalTranscript";
-  /** @description Whether the text has been punctuated and cased. */
+  /** @description Whether the text is punctuated and cased */
   punctuated: boolean;
-  /** @description Whether the text has been formatted (e.g. Dollar -> $) */
+  /** @description Whether the text is formatted, for example Dollar -> $ */
   text_formatted: boolean;
 };
 
@@ -39,32 +39,35 @@ export type MessageType =
 
 export type PartialTranscript = RealtimeBaseTranscript & {
   /**
-   * @description Describes the type of message.
+   * @description Describes the type of message
    * @constant
    */
   message_type: "PartialTranscript";
 };
 
 export type RealtimeBaseMessage = {
-  /** @description Describes the type of the message. */
+  /** @description Describes the type of the message */
   message_type: MessageType;
 };
 
 export type RealtimeBaseTranscript = {
-  /** @description End time of audio sample relative to session start, in milliseconds. */
+  /** @description End time of audio sample relative to session start, in milliseconds */
   audio_end: number;
-  /** @description Start time of audio sample relative to session start, in milliseconds. */
+  /** @description Start time of audio sample relative to session start, in milliseconds */
   audio_start: number;
   /**
    * Format: double
-   * @description The confidence score of the entire transcription, between 0 and 1.
+   * @description The confidence score of the entire transcription, between 0 and 1
    */
   confidence: number;
-  /** @description The timestamp for the partial transcript. */
+  /** @description The timestamp for the partial transcript */
   created: Date;
-  /** @description The partial transcript for your audio. */
+  /** @description The partial transcript for your audio */
   text: string;
-  /** @description An array of objects, with the information for each word in the transcription text. Includes the start/end time (in milliseconds) of the word, the confidence score of the word, and the text (i.e. the word itself). */
+  /**
+   * @description An array of objects, with the information for each word in the transcription text.
+   * Includes the start and end time of the word in milliseconds, the confidence score of the word, and the text, which is the word itself.
+   */
   words: Word[];
 };
 
@@ -85,27 +88,27 @@ export type RealtimeTranscript = PartialTranscript | FinalTranscript;
 export type RealtimeTranscriptType = "PartialTranscript" | "FinalTranscript";
 
 export type SessionBegins = RealtimeBaseMessage & {
-  /** @description Timestamp when this session will expire. */
+  /** @description Timestamp when this session will expire */
   expires_at: Date;
   /**
-   * @description Describes the type of the message.
+   * @description Describes the type of the message
    * @constant
    */
   message_type: "SessionBegins";
-  /** @description Unique identifier for the established session. */
+  /** @description Unique identifier for the established session */
   session_id: string;
 };
 
 export type SessionTerminated = RealtimeBaseMessage & {
   /**
-   * @description Describes the type of the message.
+   * @description Describes the type of the message
    * @constant
    */
   message_type: "SessionTerminated";
 };
 
 export type TerminateSession = RealtimeBaseMessage & {
-  /** @description A boolean value to communicate that you wish to end your real-time session forever. */
+  /** @description Set to true to end your real-time session forever */
   terminate_session: boolean;
 };
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,6 @@
-export type * from "./files";
-export type * from "./transcripts";
-export type * from "./realtime";
-export type * from "./services";
-export type * from "./asyncapi.generated";
-export type * from "./openapi.generated";
+export * from "./files";
+export * from "./transcripts";
+export * from "./realtime";
+export * from "./services";
+export * from "./asyncapi.generated";
+export * from "./openapi.generated";

--- a/src/types/openapi.generated.ts
+++ b/src/types/openapi.generated.ts
@@ -14,7 +14,7 @@ type OneOf<T extends any[]> = T extends [infer Only]
   : never;
 
 /**
- * @description Will be either success, or unavailable in the rare case that the model failed.
+ * @description Either success, or unavailable in the rare case that the model failed
  * @enum {string}
  */
 export type AudioIntelligenceModelStatus = "success" | "unavailable";
@@ -34,13 +34,13 @@ export type AutoHighlightResult = {
 };
 
 /**
- * @description An array of results for the Key Phrases model, if it was enabled during the transcription request.
+ * @description An array of results for the Key Phrases model, if it is enabled.
  * See [Key phrases](https://www.assemblyai.com/docs/Models/key_phrases) for more information.
  */
 export type AutoHighlightsResult = {
   /** @description A temporally-sequential array of Key Phrases */
   results: AutoHighlightResult[];
-} | null;
+};
 
 /** @description Chapter of the audio file */
 export type Chapter = {
@@ -72,7 +72,7 @@ export type ContentSafetyLabel = {
 };
 
 export type ContentSafetyLabelResult = {
-  /** @description An array of objects, one per sensitive topic that was detected in the section */
+  /** @description An array of safety labels, one per sensitive topic that was detected in the section */
   labels: ContentSafetyLabel[];
   /** @description The sentence index at which the section ends */
   sentences_idx_end: number;
@@ -84,22 +84,26 @@ export type ContentSafetyLabelResult = {
   timestamp: Timestamp;
 };
 
+/**
+ * @description An array of results for the Content Moderation model, if it is enabled.
+ * See [Content moderation](https://www.assemblyai.com/docs/Models/content_moderation) for more information.
+ */
 export type ContentSafetyLabelsResult = {
   results: ContentSafetyLabelResult[];
   /** @description A summary of the Content Moderation severity results for the entire audio file */
   severity_score_summary: {
     [key: string]: SeverityScoreSummary;
   };
-  /** @description Will be either success, or unavailable in the rare case that the Content Moderation model failed. */
+  /** @description The status of the Content Moderation model. Either success, or unavailable in the rare case that the model failed. */
   status: AudioIntelligenceModelStatus;
   /** @description A summary of the Content Moderation confidence results for the entire audio file */
   summary: {
     [key: string]: number;
   };
-} | null;
+};
 
 export type CreateRealtimeTemporaryTokenParameters = {
-  /** @description The amount of time until the token expires in seconds. */
+  /** @description The amount of time until the token expires in seconds */
   expires_in: number;
 };
 
@@ -107,29 +111,29 @@ export type CreateRealtimeTemporaryTokenParameters = {
 export type CreateTranscriptOptionalParameters = {
   /** @description The point in time, in milliseconds, to stop transcribing in your media file */
   audio_end_at?: number;
-  /** @description The point in time, in milliseconds, to begin transcription from in your media file */
+  /** @description The point in time, in milliseconds, to begin transcribing in your media file */
   audio_start_from?: number;
   /** @description Enable [Auto Chapters](https://www.assemblyai.com/docs/Models/auto_chapters), can be true or false */
   auto_chapters?: boolean;
-  /** @description Whether Key Phrases was enabled in the transcription request, either true or false */
+  /** @description Whether Key Phrases is enabled, either true or false */
   auto_highlights?: boolean;
-  /** @description The word boost parameter value, if provided in the transcription request. */
+  /** @description The word boost parameter value */
   boost_param?: TranscriptBoostParam;
   /** @description Enable [Content Moderation](https://www.assemblyai.com/docs/Models/content_moderation), can be true or false */
   content_safety?: boolean;
   /** @description Customize how words are spelled and formatted using to and from values */
   custom_spelling?: TranscriptCustomSpelling[];
-  /** @description Whether custom topics was enabled in the transcription request, either true or false */
+  /** @description Whether custom topics is enabled, either true or false */
   custom_topics?: boolean;
-  /** @description Transcribe Filler Words, like "umm", in your media file; can be true or false. */
+  /** @description Transcribe Filler Words, like "umm", in your media file; can be true or false */
   disfluencies?: boolean;
-  /** @description Enable [Dual Channel](https://assemblyai.com/docs/Models/speech_recognition#dual-channel-transcription) transcription, can be true or false. */
+  /** @description Enable [Dual Channel](https://assemblyai.com/docs/Models/speech_recognition#dual-channel-transcription) transcription, can be true or false */
   dual_channel?: boolean;
   /** @description Enable [Entity Detection](https://www.assemblyai.com/docs/Models/entity_detection), can be true or false */
   entity_detection?: boolean;
-  /** @description Filter profanity from the transcribed text, can be true or false. */
+  /** @description Filter profanity from the transcribed text, can be true or false */
   filter_profanity?: boolean;
-  /** @description Enable Text Formatting, can be true or false. */
+  /** @description Enable Text Formatting, can be true or false */
   format_text?: boolean;
   /** @description Enable [Topic Detection](https://www.assemblyai.com/docs/Models/iab_classification), can be true or false */
   iab_categories?: boolean;
@@ -137,10 +141,10 @@ export type CreateTranscriptOptionalParameters = {
    * @description The language of your audio file. Possible values are found in [Supported Languages](https://www.assemblyai.com/docs/Concepts/supported_languages).
    * The default value is 'en_us'.
    */
-  language_code?: TranscriptLanguageCode;
-  /** @description Whether [Automatic language detection](https://www.assemblyai.com/docs/Models/speech_recognition#automatic-language-detection) was enabled in the transcription request, either true or false. */
+  language_code?: TranscriptLanguageCode | null;
+  /** @description Whether [Automatic language detection](https://www.assemblyai.com/docs/Models/speech_recognition#automatic-language-detection) is enabled, either true or false */
   language_detection?: boolean;
-  /** @description Enable Automatic Punctuation, can be true or false. */
+  /** @description Enable Automatic Punctuation, can be true or false */
   punctuate?: boolean;
   /** @description Redact PII from the transcribed text using the Redact PII model, can be true or false */
   redact_pii?: boolean;
@@ -154,13 +158,13 @@ export type CreateTranscriptOptionalParameters = {
   /** @description The list of PII Redaction policies to enable. See [PII redaction](https://www.assemblyai.com/docs/Models/pii_redaction) for more details. */
   redact_pii_policies?: PiiPolicy[];
   /** @description The replacement logic for detected PII, can be "entity_type" or "hash". See [PII redaction](https://www.assemblyai.com/docs/Models/pii_redaction) for more details. */
-  redact_pii_sub?: SubstitutionPolicy;
+  redact_pii_sub?: SubstitutionPolicy | null;
   /** @description Enable [Sentiment Analysis](https://www.assemblyai.com/docs/Models/sentiment_analysis), can be true or false */
   sentiment_analysis?: boolean;
   /** @description Enable [Speaker diarization](https://www.assemblyai.com/docs/Models/speaker_diarization), can be true or false */
   speaker_labels?: boolean;
   /**
-   * @description Tells the speaker label model how many speakers it should attempt to identify, up to 10. See [Speaker diarization](https://www.assemblyai.com/docs/Models/speaker_diarization) for more details.
+   * @description Tell the speaker label model how many speakers it should attempt to identify, up to 10. See [Speaker diarization](https://www.assemblyai.com/docs/Models/speaker_diarization) for more details.
    * @default null
    */
   speakers_expected?: number | null;
@@ -184,21 +188,21 @@ export type CreateTranscriptOptionalParameters = {
    * @default bullets
    */
   summary_type?: SummaryType;
-  /** @description The list of custom topics provided if custom topics was enabled in the transcription request */
+  /** @description The list of custom topics provided, if custom topics is enabled */
   topics?: string[];
   /**
-   * @description The header name which should be sent back with webhook calls, if provided in the transcription request.
+   * @description The header name which should be sent back with webhook calls
    * @default null
    */
   webhook_auth_header_name?: string | null;
   /**
-   * @description Defaults to null. Optionally allows a user to specify a header name and value to send back with a webhook call for added security.
+   * @description Specify a header name and value to send back with a webhook call for added security
    * @default null
    */
   webhook_auth_header_value?: string | null;
-  /** @description The URL to which we send webhooks upon trancription completion, if provided in the transcription request. */
+  /** @description The URL to which AssemblyAI send webhooks upon trancription completion */
   webhook_url?: string;
-  /** @description The list of custom vocabulary to boost transcription probability for, if provided in the transcription request. */
+  /** @description The list of custom vocabulary to boost transcription probability for */
   word_boost?: string[];
 };
 
@@ -265,7 +269,7 @@ export type Error = {
 export type LemurActionItemsParameters = LemurBaseParameters;
 
 export type LemurActionItemsResponse = LemurBaseResponse & {
-  /** @description The response generated by LeMUR. */
+  /** @description The response generated by LeMUR */
   response: string;
 };
 
@@ -280,7 +284,12 @@ export type LemurBaseParameters = {
     ]
   >;
   final_model?: LemurModel;
-  /** @description Max output size in tokens. Up to 4000 allowed. */
+  /**
+   * @description Custom formatted transcript data. Maximum size is the context limit of the selected model, which defaults to 100000.
+   * Use either transcript_ids or input_text as input into LeMUR.
+   */
+  input_text?: string;
+  /** @description Max output size in tokens, up to 4000 */
   max_output_size?: number;
   /**
    * Format: float
@@ -289,8 +298,11 @@ export type LemurBaseParameters = {
    * Can be any value between 0.0 and 1.0 inclusive.
    */
   temperature?: number;
-  /** @description A list of completed transcripts with text. Up to 100 files max, or 100 hours max. Whichever is lower. */
-  transcript_ids: string[];
+  /**
+   * @description A list of completed transcripts with text. Up to a maximum of 100 files or 100 hours, whichever is lower.
+   * Use either transcript_ids or input_text as input into LeMUR.
+   */
+  transcript_ids?: string[];
 };
 
 export type LemurBaseResponse = {
@@ -310,7 +322,7 @@ export type LemurQuestion = {
   answer_format?: string;
   /** @description What discrete options to return. Useful for precise responses. Can't be used with answer_format. Example: ["Yes", "No"] */
   answer_options?: string[];
-  /** @description Any context about the transcripts you wish to provide. This can be a string, or free-form JSON. */
+  /** @description Any context about the transcripts you wish to provide. This can be a string or any object. */
   context?: OneOf<
     [
       string,
@@ -323,21 +335,21 @@ export type LemurQuestion = {
   question: string;
 };
 
-/** @description An answer generated by LeMUR and its question. */
+/** @description An answer generated by LeMUR and its question */
 export type LemurQuestionAnswer = {
-  /** @description The answer generated by LeMUR. */
+  /** @description The answer generated by LeMUR */
   answer: string;
-  /** @description The question for LeMUR to answer. */
+  /** @description The question for LeMUR to answer */
   question: string;
 };
 
 export type LemurQuestionAnswerParameters = LemurBaseParameters & {
-  /** @description A list of questions to ask. */
+  /** @description A list of questions to ask */
   questions: LemurQuestion[];
 };
 
 export type LemurQuestionAnswerResponse = LemurBaseResponse & {
-  /** @description The answers generated by LeMUR and their questions. */
+  /** @description The answers generated by LeMUR and their questions */
   response: LemurQuestionAnswer[];
 };
 
@@ -347,7 +359,7 @@ export type LemurSummaryParameters = LemurBaseParameters & {
 };
 
 export type LemurSummaryResponse = LemurBaseResponse & {
-  /** @description The response generated by LeMUR. */
+  /** @description The response generated by LeMUR */
   response: string;
 };
 
@@ -357,7 +369,7 @@ export type LemurTaskParameters = LemurBaseParameters & {
 };
 
 export type LemurTaskResponse = LemurBaseResponse & {
-  /** @description The response generated by LeMUR. */
+  /** @description The response generated by LeMUR */
   response: string;
 };
 
@@ -408,11 +420,11 @@ export type PiiPolicy =
   | "banking_information";
 
 export type PurgeLemurRequestDataResponse = {
-  /** @description Whether the request data was deleted. */
+  /** @description Whether the request data was deleted */
   deleted: boolean;
-  /** @description The ID of the LeMUR request */
-  request_id: string;
   /** @description The ID of the deletion request of the LeMUR request */
+  request_id: string;
+  /** @description The ID of the LeMUR request to purge the data for */
   request_id_to_purge: string;
 };
 
@@ -445,7 +457,7 @@ export type SentencesResponse = {
 /** @enum {unknown} */
 export type Sentiment = "POSITIVE" | "NEUTRAL" | "NEGATIVE";
 
-/** @description The result of the sentiment analysis model. */
+/** @description The result of the sentiment analysis model */
 export type SentimentAnalysisResult = {
   /**
    * Format: double
@@ -475,7 +487,7 @@ export type SeverityScoreSummary = {
 
 /**
  * @description The replacement logic for detected PII, can be "entity_type" or "hash". See [PII redaction](https://www.assemblyai.com/docs/Models/pii_redaction) for more details.
- * @enum {string|null}
+ * @enum {string}
  */
 export type SubstitutionPolicy = "entity_type" | "hash";
 
@@ -504,7 +516,7 @@ export type SummaryType =
   | "headline"
   | "paragraph";
 
-/** @description Timestamp containing a start and end property in milliseconds. */
+/** @description Timestamp containing a start and end property in milliseconds */
 export type Timestamp = {
   /** @description The end time in milliseconds */
   end: number;
@@ -512,7 +524,22 @@ export type Timestamp = {
   start: number;
 };
 
-/** @description The result of the topic detection model. */
+/**
+ * @description The result of the Topic Detection model, if it is enabled.
+ * See [Topic Detection](https://www.assemblyai.com/docs/Models/iab_classification) for more information.
+ */
+export type TopicDetectionModelResult = {
+  /** @description An array of results for the Topic Detection model */
+  results: TopicDetectionResult[];
+  /** @description The status of the Topic Detection model. Either success, or unavailable in the rare case that the model failed. */
+  status: AudioIntelligenceModelStatus;
+  /** @description The overall relevance of topic to the entire audio file */
+  summary: {
+    [key: string]: number;
+  };
+};
+
+/** @description The result of the topic detection model */
 export type TopicDetectionResult = {
   labels?: {
     /** @description The IAB taxonomical label for the label of the detected topic, where > denotes supertopic/subtopic relationship */
@@ -532,7 +559,7 @@ export type TopicDetectionResult = {
 export type Transcript = {
   /**
    * @deprecated
-   * @description The acoustic model that was used for the transcription
+   * @description The acoustic model that was used for the transcript
    */
   acoustic_model: string;
   /**
@@ -540,22 +567,22 @@ export type Transcript = {
    * @description The duration of this transcript object's media file, in seconds
    */
   audio_duration?: number | null;
-  /** @description The point in time, in milliseconds, in the file at which the transcription was terminated, if provided in the transcription request */
+  /** @description The point in time, in milliseconds, in the file at which the transcription was terminated */
   audio_end_at?: number | null;
-  /** @description The point in time, in milliseconds, in the file at which the transcription was started, if provided in the transcription request */
+  /** @description The point in time, in milliseconds, in the file at which the transcription was started */
   audio_start_from?: number | null;
   /** @description The URL of the media that was transcribed */
   audio_url: string;
-  /** @description Enable [Auto Chapters](https://www.assemblyai.com/docs/Models/auto_chapters), can be true or false */
+  /** @description Whether [Auto Chapters](https://www.assemblyai.com/docs/Models/auto_chapters) is enabled, can be true or false */
   auto_chapters?: boolean | null;
-  /** @description Whether Key Phrases was enabled in the transcription request, either true or false */
+  /** @description Whether Key Phrases is enabled, either true or false */
   auto_highlights: boolean;
   /**
-   * @description An array of results for the Key Phrases model, if it was enabled during the transcription request.
+   * @description An array of results for the Key Phrases model, if it is enabled.
    * See [Key phrases](https://www.assemblyai.com/docs/Models/key_phrases) for more information.
    */
-  auto_highlights_result?: AutoHighlightsResult;
-  /** @description The word boost parameter value, if provided in the transcription request */
+  auto_highlights_result?: AutoHighlightsResult | null;
+  /** @description The word boost parameter value */
   boost_param?: string | null;
   /** @description An array of temporally sequential chapters for the audio file */
   chapters?: Chapter[] | null;
@@ -564,51 +591,42 @@ export type Transcript = {
    * @description The confidence score for the transcript, between 0.0 (low confidence) and 1.0 (high confidence)
    */
   confidence?: number | null;
-  /** @description Enable [Content Moderation](https://www.assemblyai.com/docs/Models/content_moderation), can be true or false */
+  /** @description Whether [Content Moderation](https://www.assemblyai.com/docs/Models/content_moderation) is enabled, can be true or false */
   content_safety?: boolean | null;
   /**
-   * @description An array of results for the Content Moderation model, if it was enabled during the transcription request.
+   * @description An array of results for the Content Moderation model, if it is enabled.
    * See [Content moderation](https://www.assemblyai.com/docs/Models/content_moderation) for more information.
    */
-  content_safety_labels?: ContentSafetyLabelsResult;
+  content_safety_labels?: ContentSafetyLabelsResult | null;
   /** @description Customize how words are spelled and formatted using to and from values */
   custom_spelling?: TranscriptCustomSpelling[] | null;
-  /** @description Whether custom topics was enabled in the transcription request, either true or false */
+  /** @description Whether custom topics is enabled, either true or false */
   custom_topics?: boolean | null;
   /** @description Transcribe Filler Words, like "umm", in your media file; can be true or false */
   disfluencies?: boolean | null;
-  /** @description Whether [Dual channel transcription](https://www.assemblyai.com/docs/Models/speech_recognition#dual-channel-transcription) was enabled in the transcription request, either true or false */
+  /** @description Whether [Dual channel transcription](https://www.assemblyai.com/docs/Models/speech_recognition#dual-channel-transcription) is enabled, either true or false */
   dual_channel?: boolean | null;
   /**
-   * @description An array of results for the Entity Detection model, if it was enabled during the transcription request.
+   * @description An array of results for the Entity Detection model, if it is enabled.
    * See [Entity detection](https://www.assemblyai.com/docs/Models/entity_detection) for more information.
    */
   entities?: Entity[] | null;
-  /** @description Enable [Entity Detection](https://www.assemblyai.com/docs/Models/entity_detection), can be true or false */
+  /** @description Whether [Entity Detection](https://www.assemblyai.com/docs/Models/entity_detection) is enabled, can be true or false */
   entity_detection?: boolean | null;
   /** @description Error message of why the transcript failed */
   error?: string;
-  /** @description Whether [Profanity Filtering](https://www.assemblyai.com/docs/Models/speech_recognition#profanity-filtering) was enabled in the transcription request, either true or false */
+  /** @description Whether [Profanity Filtering](https://www.assemblyai.com/docs/Models/speech_recognition#profanity-filtering) is enabled, either true or false */
   filter_profanity?: boolean | null;
-  /** @description Whether Text Formatting was enabled in the transcription request, either true or false */
+  /** @description Whether Text Formatting is enabled, either true or false */
   format_text?: boolean | null;
-  /** @description Enable [Topic Detection](https://www.assemblyai.com/docs/Models/iab_classification), can be true or false */
+  /** @description Whether [Topic Detection](https://www.assemblyai.com/docs/Models/iab_classification) is enabled, can be true or false */
   iab_categories?: boolean | null;
   /**
-   * @description The result of the Topic Detection model, if it was enabled during the transcription request.
+   * @description The result of the Topic Detection model, if it is enabled.
    * See [Topic Detection](https://www.assemblyai.com/docs/Models/iab_classification) for more information.
    */
-  iab_categories_result?: {
-    /** @description An array of results for the Topic Detection model. */
-    results: TopicDetectionResult[];
-    /** @description Will be either success, or unavailable in the rare case that the Content Moderation model failed. */
-    status: AudioIntelligenceModelStatus;
-    /** @description The overall relevance of topic to the entire audio file */
-    summary: {
-      [key: string]: number;
-    };
-  } | null;
-  /** @description The unique identifier of your transcription */
+  iab_categories_result?: TopicDetectionModelResult | null;
+  /** @description The unique identifier of your transcript */
   id: string;
   /**
    * @description The language of your audio file.
@@ -616,24 +634,24 @@ export type Transcript = {
    * The default value is 'en_us'.
    */
   language_code?: TranscriptLanguageCode;
-  /** @description Whether [Automatic language detection](https://www.assemblyai.com/docs/Models/speech_recognition#automatic-language-detection) was enabled in the transcription request, either true or false */
+  /** @description Whether [Automatic language detection](https://www.assemblyai.com/docs/Models/speech_recognition#automatic-language-detection) is enabled, either true or false */
   language_detection?: boolean | null;
   /**
    * @deprecated
-   * @description The language model that was used for the transcription
+   * @description The language model that was used for the transcript
    */
   language_model: string;
-  /** @description Whether Automatic Punctuation was enabled in the transcription request, either true or false. */
+  /** @description Whether Automatic Punctuation is enabled, either true or false */
   punctuate?: boolean | null;
-  /** @description Whether [PII Redaction](https://www.assemblyai.com/docs/Models/pii_redaction) was enabled in the transcription request, either true or false */
+  /** @description Whether [PII Redaction](https://www.assemblyai.com/docs/Models/pii_redaction) is enabled, either true or false */
   redact_pii: boolean;
   /**
-   * @description Whether a redacted version of the audio file was generated (enabled or disabled in the transcription request),
+   * @description Whether a redacted version of the audio file was generated,
    * either true or false. See [PII redaction](https://www.assemblyai.com/docs/Models/pii_redaction) for more information.
    */
   redact_pii_audio?: boolean | null;
   /**
-   * @description The audio quality of the PII-redacted audio file, if enabled in the transcription request.
+   * @description The audio quality of the PII-redacted audio file, if redact_pii_audio is enabled.
    * See [PII redaction](https://www.assemblyai.com/docs/Models/pii_redaction) for more information.
    */
   redact_pii_audio_quality?: string | null;
@@ -644,16 +662,16 @@ export type Transcript = {
   redact_pii_policies?: PiiPolicy[] | null;
   /** @description The replacement logic for detected PII, can be "entity_type" or "hash". See [PII redaction](https://www.assemblyai.com/docs/Models/pii_redaction) for more details. */
   redact_pii_sub?: SubstitutionPolicy;
-  /** @description Enable [Sentiment Analysis](https://www.assemblyai.com/docs/Models/sentiment_analysis), can be true or false */
+  /** @description Whether [Sentiment Analysis](https://www.assemblyai.com/docs/Models/sentiment_analysis) is enabled, can be true or false */
   sentiment_analysis?: boolean | null;
   /**
-   * @description An array of results for the Sentiment Analysis model, if it was enabled during the transcription request.
+   * @description An array of results for the Sentiment Analysis model, if it is enabled.
    * See [Sentiment analysis](https://www.assemblyai.com/docs/Models/sentiment_analysis) for more information.
    */
   sentiment_analysis_results?: SentimentAnalysisResult[] | null;
-  /** @description Enable [Speaker diarization](https://www.assemblyai.com/docs/Models/speaker_diarization), can be true or false */
+  /** @description Whether [Speaker diarization](https://www.assemblyai.com/docs/Models/speaker_diarization) is enabled, can be true or false */
   speaker_labels?: boolean | null;
-  /** @description Defaults to null. Tells the speaker label model how many speakers it should attempt to identify, up to 10. See [Speaker diarization](https://www.assemblyai.com/docs/Models/speaker_diarization) for more details. */
+  /** @description Tell the speaker label model how many speakers it should attempt to identify, up to 10. See [Speaker diarization](https://www.assemblyai.com/docs/Models/speaker_diarization) for more details. */
   speakers_expected?: number | null;
   /**
    * Format: float
@@ -663,42 +681,42 @@ export type Transcript = {
   speech_threshold?: number | null;
   /**
    * @deprecated
-   * @description Whether speed boost was enabled in the transcription request
+   * @description Whether speed boost is enabled
    */
   speed_boost?: boolean | null;
-  /** @description The status of your transcription. Possible values are queued, processing, completed, or error. */
+  /** @description The status of your transcript. Possible values are queued, processing, completed, or error. */
   status: TranscriptStatus;
-  /** @description Whether [Summarization](https://www.assemblyai.com/docs/Models/summarization) was enabled in the transcription request, either true or false */
+  /** @description Whether [Summarization](https://www.assemblyai.com/docs/Models/summarization) is enabled, either true or false */
   summarization: boolean;
-  /** @description The generated summary of the media file, if [Summarization](https://www.assemblyai.com/docs/Models/summarization) was enabled in the transcription request */
+  /** @description The generated summary of the media file, if [Summarization](https://www.assemblyai.com/docs/Models/summarization) is enabled */
   summary?: string | null;
   /**
    * @description The Summarization model used to generate the summary,
-   * if [Summarization](https://www.assemblyai.com/docs/Models/summarization) was enabled in the transcription request
+   * if [Summarization](https://www.assemblyai.com/docs/Models/summarization) is enabled
    */
   summary_model?: string | null;
-  /** @description The type of summary generated, if [Summarization](https://www.assemblyai.com/docs/Models/summarization) was enabled in the transcription request */
+  /** @description The type of summary generated, if [Summarization](https://www.assemblyai.com/docs/Models/summarization) is enabled */
   summary_type?: string | null;
   /** @description The textual transcript of your media file */
   text?: string | null;
   /** @description True while a request is throttled and false when a request is no longer throttled */
   throttled?: boolean | null;
-  /** @description The list of custom topics provided if custom topics was enabled in the transcription request */
+  /** @description The list of custom topics provided if custom topics is enabled */
   topics?: string[];
   /**
    * @description When dual_channel or speaker_labels is enabled, a list of turn-by-turn utterance objects.
    * See [Speaker diarization](https://www.assemblyai.com/docs/Models/speaker_diarization) for more information.
    */
   utterances?: TranscriptUtterance[] | null;
-  /** @description Whether webhook authentication details were provided in the transcription request */
+  /** @description Whether webhook authentication details were provided */
   webhook_auth: boolean;
-  /** @description The header name which should be sent back with webhook calls, if provided in the transcription request */
+  /** @description The header name which should be sent back with webhook calls */
   webhook_auth_header_name?: string | null;
-  /** @description The status code we received from your server when delivering your webhook, if a webhook URL was provided in the transcription request */
+  /** @description The status code we received from your server when delivering your webhook, if a webhook URL was provided */
   webhook_status_code?: number | null;
-  /** @description The URL to which we send webhooks upon trancription completion, if provided in the transcription request */
+  /** @description The URL to which we send webhooks upon trancription completion */
   webhook_url?: string | null;
-  /** @description The list of custom vocabulary to boost transcription probability for, if provided in the transcription request */
+  /** @description The list of custom vocabulary to boost transcription probability for */
   word_boost?: string[];
   /**
    * @description An array of temporally-sequential word objects, one for each word in the transcript.
@@ -708,7 +726,7 @@ export type Transcript = {
 };
 
 /**
- * @description The word boost parameter value, if provided in the transcription request.
+ * @description The word boost parameter value
  * @enum {string}
  */
 export type TranscriptBoostParam = "low" | "default" | "high";
@@ -726,7 +744,7 @@ export type TranscriptCustomSpelling = {
  * The default value is 'en_us'.
  *
  * @default en_us
- * @enum {string|null}
+ * @enum {string}
  */
 export type TranscriptLanguageCode =
   | "en"
@@ -805,7 +823,7 @@ export type TranscriptSentence = {
 };
 
 /**
- * @description The status of your transcription. Possible values are queued, processing, completed, or error.
+ * @description The status of your transcript. Possible values are queued, processing, completed, or error.
  * @enum {string}
  */
 export type TranscriptStatus = "queued" | "processing" | "completed" | "error";

--- a/src/types/services/index.ts
+++ b/src/types/services/index.ts
@@ -3,5 +3,5 @@ type BaseServiceParams = {
   baseUrl?: string;
 };
 
-export type * from "./abstractions";
+export * from "./abstractions";
 export type { BaseServiceParams };

--- a/src/types/transcripts/index.ts
+++ b/src/types/transcripts/index.ts
@@ -1,5 +1,19 @@
-export type CreateTranscriptOptions = {
-  poll?: boolean;
+export type PollingOptions = {
+  /**
+   * The amount of time to wait between polling requests.
+   * @default 3000 or every 3 seconds
+   */
   pollingInterval?: number;
+  /**
+   * The maximum amount of time to wait for the transcript to be ready.
+   * @default -1 which means wait forever
+   */
   pollingTimeout?: number;
 };
+export type CreateTranscriptOptions = {
+  /**
+   * Whether to poll the transcript until it is ready.
+   * @default true
+   */
+  poll?: boolean;
+} & PollingOptions;

--- a/tests/transcript.test.ts
+++ b/tests/transcript.test.ts
@@ -99,6 +99,30 @@ describe('transcript', () => {
     expect(transcript.status).toBe('completed')
   }, 6000)
 
+  it('should wait on the transcript until ready', async () => {
+    fetchMock.doMockOnceIf(
+      requestMatches({ url: `/v2/transcript/${transcriptId}`, method: 'GET' }),
+      JSON.stringify({ status: 'queued', id: transcriptId })
+    )
+    fetchMock.doMockOnceIf(
+      requestMatches({ url: `/v2/transcript/${transcriptId}`, method: 'GET' }),
+      JSON.stringify({ status: 'processing' })
+    )
+    fetchMock.doMockOnceIf(
+      requestMatches({ url: `/v2/transcript/${transcriptId}`, method: 'GET' }),
+      JSON.stringify({ status: 'completed' })
+    )
+    const transcript = await assembly.transcripts.waitUntilReady(
+      transcriptId,
+      {
+        pollingInterval: 1000,
+        pollingTimeout: 5000,
+      },
+    )
+
+    expect(transcript.status).toBe('completed')
+  }, 6000)
+
   it('should retrieve a page of transcripts', async () => {
     fetchMock.doMockOnceIf(
       requestMatches({ url: '/v2/transcript', method: 'GET' }),
@@ -193,20 +217,20 @@ describe('transcript', () => {
 
   it('should get srt subtitles', async () => {
     fetchMock.doMockOnceIf(
-      requestMatches({ url: `/v2/transcript/${transcriptId}/srt`, method: 'GET' }),
+      requestMatches({ url: `/v2/transcript/${transcriptId}/srt?chars_per_caption=32`, method: 'GET' }),
       'Lorem ipsum'
     )
-    const subtitle = await assembly.transcripts.subtitles(transcriptId, 'srt')
+    const subtitle = await assembly.transcripts.subtitles(transcriptId, 'srt', 32)
 
     expect(subtitle).toBeTruthy()
   })
 
   it('should get vtt subtitles', async () => {
     fetchMock.doMockOnceIf(
-      requestMatches({ url: `/v2/transcript/${transcriptId}/vtt`, method: 'GET' }),
+      requestMatches({ url: `/v2/transcript/${transcriptId}/vtt?chars_per_caption=32`, method: 'GET' }),
       'Lorem ipsum'
     )
-    const subtitle = await assembly.transcripts.subtitles(transcriptId, 'vtt')
+    const subtitle = await assembly.transcripts.subtitles(transcriptId, 'vtt', 32)
 
     expect(subtitle).toBeTruthy()
   })


### PR DESCRIPTION
# Added
- Add `AssemblyAI.transcripts.waitUntilReady` function to wait until a transcript is ready, meaning `status` is `completed` or `error`.
- Add `chars_per_caption` parameter to `AssemblyAI.transcripts.subtitles` function.
- Add `input_text` property to LeMUR functions. Instead of using `transcript_ids`, you can use `input_text` to provide custom formatted transcripts as input to LeMUR.

# Changed
- Change default timeout from 3 minutes to infinite (-1). Fixes [#17](https://github.com/AssemblyAI/assemblyai-node-sdk/issues/17)

# Fixed
- Correctly serialize the keywords for `client.transcripts.wordSearch`.
- Use more widely compatible syntax for wildcard exporting types. Fixes [#18](https://github.com/AssemblyAI/assemblyai-node-sdk/issues/18).