### PR TITLE
feat: add localization option to language_detection_options

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "assemblyai",
-  "version": "4.36.4",
+  "version": "4.36.5",
   "description": "The AssemblyAI JavaScript SDK provides an easy-to-use interface for interacting with the AssemblyAI API, which supports async and real-time transcription, as well as the latest LeMUR models.",
   "engines": {
     "node": ">=18"

--- a/src/types/openapi.generated.ts
+++ b/src/types/openapi.generated.ts
@@ -1726,6 +1726,10 @@ export type LanguageDetectionOptions = {
    * The language detection model to use.
    */
   language_detection_model?: string | null;
+  /**
+   * Locale codes (e.g. ["en_au"]) to render detected English in a regional spelling variant. At most one locale per language.
+   */
+  localization?: string[] | null;
 };
 
 /**


### PR DESCRIPTION
## Summary

Adds the `localization` option to `language_detection_options`, exposing a new field available in the AssemblyAI API. When language detection resolves to English, `localization` renders the transcript text in a regional spelling variant (e.g. `en_au`, `en_uk`) while detection and code-switching continue to work as before.

## Changes

- Add `localization?: string[] | null` to `LanguageDetectionOptions`
- Bump version to `4.36.5`

## Usage

```ts
const transcript = await client.transcripts.transcribe({
  audio: audioUrl,
  language_detection: true,
  language_detection_options: {
    localization: ["en_au"],
  },
});
```
