### PR TITLE
feat: add speech_model_used to sentences and paragraphs responses

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "assemblyai",
-  "version": "4.36.4",
+  "version": "4.36.5",
   "description": "The AssemblyAI JavaScript SDK provides an easy-to-use interface for interacting with the AssemblyAI API, which supports async and real-time transcription, as well as the latest LeMUR models.",
   "engines": {
     "node": ">=18"

--- a/src/types/openapi.generated.ts
+++ b/src/types/openapi.generated.ts
@@ -1186,6 +1186,10 @@ export type ParagraphsResponse = {
    * An array of paragraphs in the transcript
    */
   paragraphs: TranscriptParagraph[];
+  /**
+   * The actual speech model that was used for the transcription
+   */
+  speech_model_used?: string | null;
 };
 
 /**
@@ -1430,6 +1434,10 @@ export type SentencesResponse = {
    * An array of sentences in the transcript
    */
   sentences: TranscriptSentence[];
+  /**
+   * The actual speech model that was used for the transcription
+   */
+  speech_model_used?: string | null;
 };
 
 export type Sentiment = "POSITIVE" | "NEUTRAL" | "NEGATIVE";

--- a/tests/unit/transcript.test.ts
+++ b/tests/unit/transcript.test.ts
@@ -360,13 +360,18 @@ describe("transcript", () => {
         url: `/v2/transcript/${transcriptId}/paragraphs`,
         method: "GET",
       }),
-      JSON.stringify({ transcriptId, paragraphs: ["paragraph 1"] }),
+      JSON.stringify({
+        transcriptId,
+        paragraphs: ["paragraph 1"],
+        speech_model_used: "universal-2",
+      }),
     );
     const paragraphsResponse =
       await assembly.transcripts.paragraphs(transcriptId);
 
     expect(paragraphsResponse.paragraphs).toBeInstanceOf(Array);
     expect(paragraphsResponse.paragraphs.length).toBeGreaterThan(0);
+    expect(paragraphsResponse.speech_model_used).toBe("universal-2");
   });
 
   it("should get sentences", async () => {
@@ -375,13 +380,18 @@ describe("transcript", () => {
         url: `/v2/transcript/${transcriptId}/sentences`,
         method: "GET",
       }),
-      JSON.stringify({ transcriptId, sentences: ["sentence 1"] }),
+      JSON.stringify({
+        transcriptId,
+        sentences: ["sentence 1"],
+        speech_model_used: "universal-2",
+      }),
     );
     const sentencesResponse =
       await assembly.transcripts.sentences(transcriptId);
 
     expect(sentencesResponse.sentences).toBeInstanceOf(Array);
     expect(sentencesResponse.sentences.length).toBeGreaterThan(0);
+    expect(sentencesResponse.speech_model_used).toBe("universal-2");
   });
 
   it("should get srt subtitles", async () => {


### PR DESCRIPTION
The API now returns speech_model_used on GET /v2/transcript/{id}/sentences and /paragraphs.