### PR TITLE
feat(streaming): add universal-3-6-pro speech model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [4.37.1]
+
+- Add `universal-3-6-pro` to the streaming `speechModel` options (`StreamingSpeechModel`)
+
 ## [4.37.0]
 
 - Remove LeMUR support — the LeMUR API has been shut down and its endpoints answer 404. `client.lemur`, `LemurService`, and all Lemur request/response types are removed. For LeMUR-style workloads, use the LLM Gateway (`llm-gateway.assemblyai.com/v1/chat/completions`); it takes transcript text rather than `transcript_ids`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "assemblyai",
-  "version": "4.37.0",
+  "version": "4.37.1",
   "description": "The AssemblyAI JavaScript SDK provides an easy-to-use interface for interacting with the AssemblyAI API, which supports async and real-time transcription.",
   "engines": {
     "node": ">=18"

--- a/src/types/streaming/index.ts
+++ b/src/types/streaming/index.ts
@@ -209,6 +209,7 @@ export type StreamingSpeechModel =
   | "u3-rt-pro-beta-1"
   | "whisper-rt"
   | "universal-3-5-pro"
+  | "universal-3-6-pro"
   | "u3-pro";
 
 export type StreamingDomain = "medical-v1";

--- a/tests/unit/streaming.test.ts
+++ b/tests/unit/streaming.test.ts
@@ -503,6 +503,23 @@ describe("streaming", () => {
     await connect(rt, server);
   });
 
+  it("should include universal-3-6-pro speech model in connection URL", async () => {
+    await cleanup();
+    WS.clean();
+
+    const wsUrl = `${websocketBaseUrl}?token=123&sample_rate=16000&speech_model=universal-3-6-pro`;
+    server = new WS(wsUrl);
+    rt = new StreamingTranscriber({
+      websocketBaseUrl,
+      token: "123",
+      sampleRate: 16_000,
+      speechModel: "universal-3-6-pro" as const,
+    });
+    onOpen = jest.fn();
+    rt.on("open", onOpen);
+    await connect(rt, server);
+  });
+
   it("should parse speaker_label from turn event", async () => {
     const turnPromise = new Promise<{ speaker_label?: string }>((resolve) => {
       rt.on("turn", (event) => resolve(event));


### PR DESCRIPTION
## Summary

Adds `universal-3-6-pro` to the `StreamingSpeechModel` union so it can be passed as `speechModel` on `client.streaming.transcriber(...)`:

```typescript
const transcriber = client.streaming.transcriber({
  speechModel: "universal-3-6-pro",
  sampleRate: 16_000,
});
```

The streaming service passes `speechModel` straight through to the `speech_model` query parameter with no allowlist validation, so the union entry is the only change needed to make the model selectable in a type-safe way. Previously callers had to cast to reach it.

Scope is streaming only — the pre-recorded `SpeechModel` and the sync `SyncSpeechModel` are untouched.

## Changes

- `src/types/streaming/index.ts` — add `"universal-3-6-pro"` to `StreamingSpeechModel`
- `tests/unit/streaming.test.ts` — assert the model reaches the connection URL, mirroring the existing `universal-3-5-pro` test
- `CHANGELOG.md` / `package.json` — 4.37.1

## Testing

- `tsc --noEmit` passes
- `jest --config jest.unit.config.js` — 222 passed, 3 failed. The 3 failures are pre-existing on `main` (the `utils › should build a user-agent` tests, which expect `runtime_env=Node/` and don't detect Node 23) and unrelated to this change.
- `eslint` and `prettier --check` clean

## Note for reviewers

A few doc comments in `src/types/streaming/index.ts` scope features to "Universal-3.5 Pro Streaming only" (`languageCodes`, `agentContext`, and `sessionHeartbeat` in the changelog). I left them as-is since I can't confirm whether 3.6 Pro supports them — worth a follow-up if it does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)