### PR TITLE
feat: raise the sync config caps to match the service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [4.39.1]
+
+- Raise the `client.sync` config caps to match the service (the API raised them; the SDK was rejecting values the server now accepts): `prompt` 4096 → 6000 characters, `keyterms_prompt` 2048 → 8000 characters, and `conversation_context` 100 → 500 turns / 4096 → 16 000 characters. `keyterms_prompt` also gains the server's 100-term cap, which the SDK did not enforce
+
 ## [4.39.0]
 
 - Add `client.sync.transcribeLive(audio, config?, options?)` — sync transcription that uploads audio while it is still being recorded, from an async iterable (Node streams included), a sync iterable, or a web `ReadableStream`. The request starts before the audio exists, so authorization, the upload and every speech segment but the last resolve while the caller is still recording. Audio already held whole (bytes, a Blob, a path) is rejected by name — it belongs in `transcribe()`, which is faster for it

--- a/README.md
+++ b/README.md
@@ -332,8 +332,8 @@ stream — but not a URL.
 
 ```typescript
 const result = await client.sync.transcribe("./call.wav", {
-  prompt: "Transcribe verbatim. Preserve disfluencies.", // max 4096 chars
-  keyterms_prompt: ["AssemblyAI", "Lemur"], // max 2048 chars total
+  prompt: "Transcribe verbatim. Preserve disfluencies.", // max 6000 chars
+  keyterms_prompt: ["AssemblyAI", "Lemur"], // max 100 terms / 8000 chars total
   language_codes: ["es"], // or e.g. ["en", "es"] for multilingual; defaults to English
   conversation_context: [
     // prior turns, oldest first

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "assemblyai",
-  "version": "4.39.0",
+  "version": "4.39.1",
   "description": "The AssemblyAI JavaScript SDK provides an easy-to-use interface for interacting with the AssemblyAI API, which supports async and real-time transcription.",
   "engines": {
     "node": ">=18"

--- a/src/services/sync/service.ts
+++ b/src/services/sync/service.ts
@@ -34,10 +34,14 @@ const defaultTimeoutMs = 60_000;
 // default must clear the 120 s audio cap plus the final segment.
 const defaultLiveTimeoutMs = 180_000;
 const warmTimeoutMs = 10_000;
-const maxPromptLength = 4096;
-const maxKeytermsPromptLength = 2048;
-const maxContextTurns = 100;
-const maxContextLength = 4096;
+// Caps mirror the sync service's `config` part. `prompt` and
+// `keyterms_prompt` over their caps are rejected; `conversation_context` over
+// its caps is trimmed, oldest turns first.
+const maxPromptLength = 6000;
+const maxKeytermsPromptLength = 8000;
+const maxKeytermsCount = 100;
+const maxContextTurns = 500;
+const maxContextLength = 16000;
 // Extensions that signal raw S16LE PCM rather than a WAV container.
 const pcmSuffixes = [".pcm", ".raw"];
 
@@ -434,6 +438,11 @@ function normalizeKeytermsPrompt(
   const terms = keytermsPrompt
     .map((term) => term.trim())
     .filter((term) => term.length > 0);
+  if (terms.length > maxKeytermsCount) {
+    throw new Error(
+      `keyterms_prompt exceeds ${maxKeytermsCount} terms (got ${terms.length})`,
+    );
+  }
   const total = terms.reduce((sum, term) => sum + term.length, 0);
   if (total > maxKeytermsPromptLength) {
     throw new Error(

--- a/tests/unit/sync.test.ts
+++ b/tests/unit/sync.test.ts
@@ -146,15 +146,15 @@ describe("sync", () => {
   it("should trim the oldest conversation turns over the char cap", async () => {
     mockOk();
     await assembly.sync.transcribe(fakeWavBytes, {
-      conversation_context: ["a".repeat(3000), "b".repeat(3000)],
+      conversation_context: ["a".repeat(10000), "b".repeat(10000)],
     });
     const config = await configPart();
-    expect(config?.conversation_context).toEqual(["b".repeat(3000)]);
+    expect(config?.conversation_context).toEqual(["b".repeat(10000)]);
   });
 
   it("should trim the oldest conversation turns over the turn cap", async () => {
     mockOk();
-    const turns = Array.from({ length: 120 }, (_, i) => `turn ${i}`);
+    const turns = Array.from({ length: 520 }, (_, i) => `turn ${i}`);
     await assembly.sync.transcribe(fakeWavBytes, {
       conversation_context: turns,
     });
@@ -165,7 +165,7 @@ describe("sync", () => {
   it("should trim to nothing when a single turn is over the char cap", async () => {
     mockOk();
     await assembly.sync.transcribe(fakeWavBytes, {
-      conversation_context: ["a".repeat(5000)],
+      conversation_context: ["a".repeat(20000)],
     });
     expect(requestBody().get("config")).toBeNull();
   });
@@ -294,15 +294,24 @@ describe("sync", () => {
   it("should reject an oversized keyterms_prompt", async () => {
     await expect(
       assembly.sync.transcribe(fakeWavBytes, {
-        keyterms_prompt: ["x".repeat(3000)],
+        keyterms_prompt: ["x".repeat(9000)],
       }),
     ).rejects.toThrow("keyterms_prompt exceeds");
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
+  it("should reject a keyterms_prompt over the term count", async () => {
+    await expect(
+      assembly.sync.transcribe(fakeWavBytes, {
+        keyterms_prompt: Array.from({ length: 101 }, (_, i) => `term ${i}`),
+      }),
+    ).rejects.toThrow("keyterms_prompt exceeds 100 terms");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it("should reject an oversized prompt", async () => {
     await expect(
-      assembly.sync.transcribe(fakeWavBytes, { prompt: "x".repeat(5000) }),
+      assembly.sync.transcribe(fakeWavBytes, { prompt: "x".repeat(7000) }),
     ).rejects.toThrow("prompt exceeds");
     expect(fetchMock).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## What

Raise the client-side caps in `src/services/sync/service.ts` to the values the sync service enforces, and add the one check the SDK was missing.

| | before | after |
|---|---|---|
| `prompt` | 4096 chars | 6000 chars |
| `keyterms_prompt` | 2048 chars | 8000 chars |
| `keyterms_prompt` term count | *unchecked* | 100 terms |
| `conversation_context` | 100 turns / 4096 chars | 500 turns / 16000 chars |

Over-cap `prompt` and `keyterms_prompt` still throw before the request is sent; over-cap `conversation_context` is still trimmed oldest-first rather than rejected. Only the numbers move.

## Why

The service raised these caps ([DeepLearning#20095](https://github.com/AssemblyAI/DeepLearning/pull/20095)), so the SDK has been rejecting values the API now accepts — a caller passing a 5000-character prompt gets a client-side `Error` for a request the server would have taken. The values here match `asr_sync_u3pro/http_server/schemas.py:27-36` exactly, and the Python SDK made the same change in [1.5.2](https://github.com/AssemblyAI/assemblyai-python-sdk/pull/250).

The 100-term cap is new to this SDK: the service rejects a `keyterms_prompt` over 100 terms, and without a local check that surfaces as a server error mid-request instead of an immediate one.

## Testing

`pnpm test:unit -- tests/unit/sync.test.ts` — 34 passed. Five existing cases asserted behavior at the old caps (3000-char keyterms rejected, 5000-char prompt rejected, 120 turns trimmed, and two `conversation_context` trims) and were re-based on the new ones; added a case for the term-count cap. `pnpm lint:eslint`, `lint:tsc`, and prettier are clean on the changed files.

Pre-existing on `main`, untouched by this PR: `tests/unit/utils.test.ts` (3 user-agent assertions expecting `runtime_env=Node/`) and `tests/unit/realtime.test.ts` fail, and prettier reports 6 unformatted files under `samples/` and the generated `src/types/*.generated.ts`. Verified by running both suites with this branch's two source files reverted to `origin/main`.

## Not in this PR

`stt_prompt` is a dictation parameter, and this SDK has no dictation surface yet — the Python SDK grew one in 1.5.x. Adding `client.dictation` is a feature, not a cap change, so it's out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)