### PR TITLE
feat(streaming): add universal-3-6 speech model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [4.41.1]
+
+- Add `universal-3-6` to the streaming `speechModel` options (`StreamingSpeechModel`)
+
 ## [4.41.0]
 
 - `client.sync.transcribe()` now sends audio over the same live connection as `transcribeLive()` / `openLive()`: `POST /v1/transcribe/live` (also served at `/v1/transcribe/stream`), chunked multipart, `config` first (always present, `{}` when empty) then `audio`. A clip already held is sent as a single chunk. There is no separate buffered request any more — nothing posts to `/v1/transcribe`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "assemblyai",
-  "version": "4.41.0",
+  "version": "4.41.1",
   "description": "The AssemblyAI JavaScript SDK provides an easy-to-use interface for interacting with the AssemblyAI API, which supports async and real-time transcription.",
   "engines": {
     "node": ">=18"

--- a/src/types/streaming/index.ts
+++ b/src/types/streaming/index.ts
@@ -209,6 +209,7 @@ export type StreamingSpeechModel =
   | "u3-rt-pro-beta-1"
   | "whisper-rt"
   | "universal-3-5-pro"
+  | "universal-3-6"
   | "universal-3-6-pro"
   | "u3-pro";
 

--- a/tests/unit/streaming.test.ts
+++ b/tests/unit/streaming.test.ts
@@ -520,6 +520,23 @@ describe("streaming", () => {
     await connect(rt, server);
   });
 
+  it("should include universal-3-6 speech model in connection URL", async () => {
+    await cleanup();
+    WS.clean();
+
+    const wsUrl = `${websocketBaseUrl}?token=123&sample_rate=16000&speech_model=universal-3-6`;
+    server = new WS(wsUrl);
+    rt = new StreamingTranscriber({
+      websocketBaseUrl,
+      token: "123",
+      sampleRate: 16_000,
+      speechModel: "universal-3-6" as const,
+    });
+    onOpen = jest.fn();
+    rt.on("open", onOpen);
+    await connect(rt, server);
+  });
+
   it("should parse speaker_label from turn event", async () => {
     const turnPromise = new Promise<{ speaker_label?: string }>((resolve) => {
       rt.on("turn", (event) => resolve(event));


### PR DESCRIPTION
## Summary

Adds `universal-3-6` to the `StreamingSpeechModel` union so it can be passed as `speechModel` on `client.streaming.transcriber(...)`:

```typescript
const transcriber = client.streaming.transcriber({
  speechModel: "universal-3-6",
  sampleRate: 16_000,
});
```

The streaming service passes `speechModel` straight through to the `speech_model` query parameter, so the union entry is the only change needed to make the model selectable in a type-safe way. Same shape as #174, which added `universal-3-6-pro`.

Scope is streaming only — the pre-recorded `SpeechModel` and the sync `SyncSpeechModel` are untouched.

## Changes

- `src/types/streaming/index.ts` — add `"universal-3-6"` to `StreamingSpeechModel`
- `tests/unit/streaming.test.ts` — assert the model reaches the connection URL, mirroring the `universal-3-6-pro` test
- `CHANGELOG.md` / `package.json` — 4.41.1

## Testing

- **Live API**: connected to `streaming.assemblyai.com` with `speechModel: "universal-3-6"` and received `Begin` (session opened). A bogus model name was rejected with a validation error as a negative control, and that error enumerates the server's accepted list, which includes `universal-3-6`.
- `tsc --noEmit` passes
- `jest --config jest.unit.config.js` — 336 passed, 3 failed. The 3 failures are the pre-existing `utils › should build a user-agent` tests (they expect `runtime_env=Node/` and the builder does not detect Node 24), unrelated to this change and the same ones noted in #174.
- `eslint` and `prettier --check` clean
